### PR TITLE
Fixed icon styling and behaviour

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1393,3 +1393,11 @@ section {
     padding: 3px 0;
   }
 }
+
+/* Constraint the logo size */
+
+@media only screen and ((max-width: 300px) or (max-height: 300px)) {
+  #cordimg {
+    display: none;
+  }
+}


### PR DESCRIPTION
Solved issue : #38 


I have removed the icon when either the height and width is lesser than 300px. So now if we squeeze off, it shows something like this...

Before squeezing:
![1](https://user-images.githubusercontent.com/58508471/200173265-58f89aca-8382-4a2c-806a-1f0e6534a858.png)

And after sequeezing:
![2](https://user-images.githubusercontent.com/58508471/200173279-6a0cec6a-b3c0-481f-8a4e-40850a9f136d.png)

